### PR TITLE
Replace URI by host+port

### DIFF
--- a/cider-any-uruk.el
+++ b/cider-any-uruk.el
@@ -104,14 +104,17 @@
   "Clojure form for XQuery document revaluation."
   (format "(do
              (require '[uruk.core :as uruk])
-             (let [db %s]
-               (with-open [session (uruk/create-session db)]
+             (let [host \"%s\"
+                   port %s
+                   db %s]
+               (with-open [session (uruk/create-session {} (uruk/make-hosted-content-source host port db) {})]
                  (doall (map str (uruk/execute-xquery session \"%%s\"))))))"
+          cider-any-uruk-host
+          cider-any-uruk-port
           (cider-any-uruk-plist-to-map
-           `(:uri ,(cider-any-uruk-uri)
-             :user ,cider-any-uruk-user
-             :password ,cider-any-uruk-password
-             :content-base ,cider-any-uruk-content-base))))
+           `(:user ,cider-any-uruk-user
+                   :password ,cider-any-uruk-password
+                   :content-base ,cider-any-uruk-content-base))))
 
 (defun cider-any-uruk (command &rest args)
   "Eval XQuery in Cider.

--- a/cider-any-uruk.el
+++ b/cider-any-uruk.el
@@ -12,8 +12,13 @@
   "Evaluate XQuery documents in the cider repl."
   :group 'cider-any)
 
-(defcustom cider-any-uruk-uri nil
-  "Uri uruk/create-session argument."
+(defcustom cider-any-uruk-host nil
+  "Host uruk/create-session argument."
+  :type 'string
+  :group 'cider-any-uruk)
+
+(defcustom cider-any-uruk-port nil
+  "Port uruk/create-session argument."
   :type 'string
   :group 'cider-any-uruk)
 
@@ -90,6 +95,11 @@
        (local-set-key (kbd "q") 'quit-window)
        (current-buffer)))))
 
+(defun cider-any-uruk-uri ()
+  (format "xcc://%s:%s"
+          cider-any-uruk-host
+          cider-any-uruk-port))
+
 (defun cider-any-uruk-eval-form ()
   "Clojure form for XQuery document revaluation."
   (format "(do
@@ -98,7 +108,7 @@
                (with-open [session (uruk/create-session db)]
                  (doall (map str (uruk/execute-xquery session \"%%s\"))))))"
           (cider-any-uruk-plist-to-map
-           `(:uri ,cider-any-uruk-uri
+           `(:uri ,(cider-any-uruk-uri)
              :user ,cider-any-uruk-user
              :password ,cider-any-uruk-password
              :content-base ,cider-any-uruk-content-base))))

--- a/cider-any-uruk.el
+++ b/cider-any-uruk.el
@@ -86,10 +86,7 @@
                  (doall (map str (uruk/execute-xquery session \"%%s\"))))))"
           (plist-get cider-any-uruk-connection :host)
           (plist-get cider-any-uruk-connection :port)
-          (cider-any-uruk-plist-to-map
-           `(:user ,(plist-get cider-any-uruk-connection :user)
-                   :password ,(plist-get cider-any-uruk-connection :password)
-                   :content-base ,(plist-get cider-any-uruk-connection :content-base)))))
+          (cider-any-uruk-plist-to-map cider-any-uruk-connection)))
 
 (defun cider-any-uruk (command &rest args)
   "Eval XQuery in Cider.

--- a/cider-any-uruk.el
+++ b/cider-any-uruk.el
@@ -12,29 +12,9 @@
   "Evaluate XQuery documents in the cider repl."
   :group 'cider-any)
 
-(defcustom cider-any-uruk-host nil
-  "Host uruk/create-session argument."
-  :type 'string
-  :group 'cider-any-uruk)
-
-(defcustom cider-any-uruk-port nil
-  "Port uruk/create-session argument."
-  :type 'string
-  :group 'cider-any-uruk)
-
-(defcustom cider-any-uruk-user nil
-  "User uruk/create-session argument."
-  :type 'string
-  :group 'cider-any-uruk)
-
-(defcustom cider-any-uruk-password nil
-  "Password uruk/create-session argument."
-  :type 'string
-  :group 'cider-any-uruk)
-
-(defcustom cider-any-uruk-content-base nil
-  "Content base uruk/create-session argument."
-  :type 'string
+(defcustom cider-any-uruk-connection '(:host nil :port nil :user nil :password nil :content-base nil)
+  "Property list of :host :port :user :password :content-base for uruk session creation"
+  :type 'plist
   :group 'cider-any-uruk)
 
 (defcustom cider-any-uruk-handler 'cider-any-uruk-display-buffer
@@ -104,12 +84,12 @@
                    db %s]
                (with-open [session (uruk/create-default-session (uruk/make-hosted-content-source host port db))]
                  (doall (map str (uruk/execute-xquery session \"%%s\"))))))"
-          cider-any-uruk-host
-          cider-any-uruk-port
+          (plist-get cider-any-uruk-connection :host)
+          (plist-get cider-any-uruk-connection :port)
           (cider-any-uruk-plist-to-map
-           `(:user ,cider-any-uruk-user
-                   :password ,cider-any-uruk-password
-                   :content-base ,cider-any-uruk-content-base))))
+           `(:user ,(plist-get cider-any-uruk-connection :user)
+                   :password ,(plist-get cider-any-uruk-connection :password)
+                   :content-base ,(plist-get cider-any-uruk-connection :content-base)))))
 
 (defun cider-any-uruk (command &rest args)
   "Eval XQuery in Cider.

--- a/cider-any-uruk.el
+++ b/cider-any-uruk.el
@@ -95,11 +95,6 @@
        (local-set-key (kbd "q") 'quit-window)
        (current-buffer)))))
 
-(defun cider-any-uruk-uri ()
-  (format "xcc://%s:%s"
-          cider-any-uruk-host
-          cider-any-uruk-port))
-
 (defun cider-any-uruk-eval-form ()
   "Clojure form for XQuery document revaluation."
   (format "(do

--- a/cider-any-uruk.el
+++ b/cider-any-uruk.el
@@ -107,7 +107,7 @@
              (let [host \"%s\"
                    port %s
                    db %s]
-               (with-open [session (uruk/create-session {} (uruk/make-hosted-content-source host port db) {})]
+               (with-open [session (uruk/create-default-session (uruk/make-hosted-content-source host port db))]
                  (doall (map str (uruk/execute-xquery session \"%%s\"))))))"
           cider-any-uruk-host
           cider-any-uruk-port

--- a/project.clj
+++ b/project.clj
@@ -1,2 +1,2 @@
 (defproject test "0.0.1"
-  :dependencies [[uruk "0.3.2"]])
+  :dependencies [[uruk "0.3.3"]])

--- a/scripts/init.el
+++ b/scripts/init.el
@@ -11,7 +11,8 @@
 
 (add-hook 'xquery-mode-hook 'cider-any-mode)
 
-(setq cider-any-uruk-uri "xdbc://localhost:8889/"
+(setq cider-any-uruk-host "localhost"
+      cider-any-uruk-port "8889"
       cider-any-uruk-user "proofit404"
       cider-any-uruk-password (with-current-buffer
 				  (find-file-noselect (expand-file-name "passwd" (file-name-directory load-file-name)))


### PR DESCRIPTION
I suggest to switch from URI for host+port to separate host and port.

Reason: Actually the URI is meant to be an alternative to specify everything:
  protocol://user:password@host:port/content-base
but cider-any-uruk uses separate variables for user, password, and content-base.

So let's also split the URI into separate variables for host and port.

scripts/init.el is updated as well but I did not test it.
