### PR TITLE
Improve when reply is file

### DIFF
--- a/cider-any-uruk.el
+++ b/cider-any-uruk.el
@@ -57,6 +57,18 @@
        (browse-url (concat "file://" filename))))
    content))
 
+(defun cider-any-uruk-set-file-name (file-name)
+  ;; Don't use (set-visited-file-name file-name) anymore,
+  ;; as the file-name might contain a path that might not exist locally
+  ;; and set-visited-file-name also
+  ;;  - changes default-directory acc. to the path. and that has side effects
+  ;;  - it usually sets buffer-auto-save-file-name as well, and that leads
+  ;;    to problems for non-existing paths
+  (setq buffer-file-name file-name)
+  (normal-mode t) ;; t means: normal-mode detection as done in find-file
+  (rename-buffer file-name t) ;; t means: make buffer name unique if not so already
+  )
+
 (defun cider-any-uruk-display-buffer (&rest content)
   "Show CONTENT in the buffer."
   (if (not content)
@@ -65,7 +77,7 @@
      (with-current-buffer
          (get-buffer-create (format cider-any-uruk-buffer-template (buffer-name)))
        (when cider-any-uruk-buffer-filename
-         (set-visited-file-name cider-any-uruk-buffer-filename)
+         (cider-any-uruk-set-file-name cider-any-uruk-buffer-filename)
          (setq cider-any-uruk-buffer-filename nil))
        (read-only-mode -1)
        (erase-buffer)

--- a/cider-any-uruk.el
+++ b/cider-any-uruk.el
@@ -76,9 +76,6 @@
     (pop-to-buffer
      (with-current-buffer
          (get-buffer-create (format cider-any-uruk-buffer-template (buffer-name)))
-       (when cider-any-uruk-buffer-filename
-         (cider-any-uruk-set-file-name cider-any-uruk-buffer-filename)
-         (setq cider-any-uruk-buffer-filename nil))
        (read-only-mode -1)
        (erase-buffer)
        (insert (car content))
@@ -88,10 +85,16 @@
          (insert "\n")
          (insert item))
        (goto-char (point-min))
-       (normal-mode)
-       (page-break-lines-mode 1)
-       (read-only-mode 1)
-       (local-set-key (kbd "q") 'quit-window)
+       (if cider-any-uruk-buffer-filename
+           (progn
+             (cider-any-uruk-set-file-name cider-any-uruk-buffer-filename)
+             (setq cider-any-uruk-buffer-filename nil))
+         ;; these settings only if we haven't set a file-name
+         (progn
+           (normal-mode)
+           (page-break-lines-mode 1)
+           (read-only-mode 1)
+           (local-set-key (kbd "q") 'quit-window)))
        (set-buffer-modified-p nil)
        (current-buffer)))))
 

--- a/cider-any-uruk.el
+++ b/cider-any-uruk.el
@@ -92,6 +92,7 @@
        (page-break-lines-mode 1)
        (read-only-mode 1)
        (local-set-key (kbd "q") 'quit-window)
+       (set-buffer-modified-p nil)
        (current-buffer)))))
 
 (defun cider-any-uruk-eval-form ()

--- a/cider-any-uruk.el
+++ b/cider-any-uruk.el
@@ -94,7 +94,16 @@
            (normal-mode)
            (page-break-lines-mode 1)
            (read-only-mode 1)
-           (local-set-key (kbd "q") 'quit-window)))
+
+           ;; local-set-key actually changes the local map which is shared with all
+           ;; other buffers in the same major map.
+           ;; Therefore, copy current keymap so that we really set to a *new* buffer
+           ;; local keymap, see https://www.emacswiki.org/emacs/BufferLocalKeys
+           (let ((local-map (current-local-map)))
+             (when local-map ;; check first if there really is a local-map
+               (use-local-map (copy-keymap local-map))))
+           (local-set-key (kbd "q") 'quit-window)
+           ))
        (set-buffer-modified-p nil)
        (current-buffer)))))
 


### PR DESCRIPTION
These changes much improve the behavior in case the reply to an XQuery is actually a file (that is, if it sets a cider-any-uruk-file-name. Please merge.

The commit log and commit itself https://github.com/xquery-mode/cider-any/commit/7ea0e4ceca870fff0ae7b14e4e38bcc69988fc83 for a description of the problems there were and how they were fixed.

Also, fix a bug that cider-any-uruk-display-buffer messed with the local keymap of a major mode if the returned file actually had a local keymap.
